### PR TITLE
fix: html default css

### DIFF
--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -5,4 +5,7 @@ module.exports = {
     extend: {},
   },
   plugins: [],
+  corePlugins: {
+    preflight: false,
+  },
 };


### PR DESCRIPTION
This pull request includes a small change to the `frontend/tailwind.config.js` file. The change disables the `preflight` core plugin in Tailwind CSS.

* [`frontend/tailwind.config.js`](diffhunk://#diff-8fdab0c1827a182dfaa61b1253086037a44105350409f6701c49ebe130f6705bR8-R10): Added `corePlugins` configuration to disable `preflight`.